### PR TITLE
Migrate requirement from sklearn to scikit-learn and fix the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: jammy
+dist: focal
 # Language
 language: python
 # Language Versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 # Language
 language: python
 # Language Versions
@@ -6,7 +7,10 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.8-dev"
+  - "3.9"
+  - "3.10"
+  - "3.11"
+  - "3.11-dev"
 # Install Script
 install:
   - pip install -U pip setuptools wheel   # Update build deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-sklearn
+scikit-learn
 wheel
 setuptools
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires='>=3.5',
-    install_requires=["sklearn", "pandas"],
-    setup_requires=["sklearn", "pandas"]
+    install_requires=["scikit-learn", "pandas"],
 )

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -1,36 +1,53 @@
 # AUTHOR: Louis Tsiattalou
 # DESCRIPTION: Test matcher module. Execute with `python -m unittest discover -s test/`
 
+import re
 import unittest
-from tfidf_matcher.ngrams import ngrams
+
+import pandas as pd
+
 from tfidf_matcher.matcher import matcher
+from tfidf_matcher.ngrams import ngrams
+
 
 class TestMatcher(unittest.TestCase):
 
     test_list = ["hello", "theseare", "definitely", "companynames"]
     test_lookup = ["hullo", "company", "finite", "cesare"]
 
+    max_k_matches = len(test_lookup) - 1
+
     def test_matcher_output_shape(self):
         """Test that the output of matcher is as expected."""
-        for k in range(1, len(self.test_lookup)):
-            self.assertEqual(matcher(self.test_list, self.test_lookup, k_matches = k).shape, (len(self.test_list), k+2))
+        for k in range(1, self.max_k_matches + 1):
+            self.assertEqual(
+                matcher(self.test_list, self.test_lookup, k_matches=k).shape,
+                (len(self.test_list), (k * 3) + 1),
+            )
 
     def test_matcher_outputs_found_in_original(self):
         """Test that all of the matched strings are found in the original."""
-        res = matcher(self.test_list, self.test_lookup, k_matches = 4)['Original Name']
+        res = matcher(self.test_list, self.test_lookup, k_matches=self.max_k_matches)[
+            "Original Name"
+        ]
         self.assertTrue(all([x in self.test_list for x in res]))
 
     def test_matcher_outputs_found_in_lookup(self):
         """Test that all of the matcher lookup outputs are found in the lookups list."""
-        res = matcher(self.test_list, self.test_lookup, k_matches = 4)
-        res = res.iloc[:,2:]
-        reslist = [list(res[x]) for x in res]
-        resset = set([x for sublist in reslist for x in sublist]) # Build unique elems in lookup set
-        self.assertTrue(all([x in self.test_lookup for x in resset]))
+        res = matcher(self.test_list, self.test_lookup, k_matches=self.max_k_matches)
+        lookup_cols = [c for c in res.columns if re.match(r"^Lookup \d+$", c)]
+        lookup_unique_values = pd.unique(res[lookup_cols].values.ravel("K"))
+        self.assertTrue(all([x in self.test_lookup for x in lookup_unique_values]))
 
     def test_matcher_scores_normalized(self):
         """Test that the matcher matchscores are between 0 and 1."""
-        res = matcher(self.test_list, self.test_lookup, k_matches = 4)['Match Confidence']
+        res = matcher(self.test_list, self.test_lookup, k_matches=self.max_k_matches)
+        confidence_cols = [
+            c for c in res.columns if re.match(r"^Lookup \d+ Confidence$", c)
+        ]
+        for confidence_col in confidence_cols:
+            self.assertTrue(all([0 <= x <= 1 for x in res[confidence_col]]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_ngrams.py
+++ b/test/test_ngrams.py
@@ -2,10 +2,11 @@
 # DESCRIPTION: Test ngrams module. Execute with `python -m unittest discover -s test/`
 
 import unittest
+
 from tfidf_matcher.ngrams import ngrams
 
-class TestNgrams(unittest.TestCase):
 
+class TestNgrams(unittest.TestCase):
     def test_ngram_count(self):
         """Test that the number of ngrams returned by the function is correct."""
         data = "This is a sentence"
@@ -21,6 +22,7 @@ class TestNgrams(unittest.TestCase):
         self.assertTrue(all([len(x) == 2 for x in ngrams(data, n=2)]))
         self.assertTrue(all([len(x) == 3 for x in ngrams(data, n=3)]))
         self.assertTrue(all([len(x) == 18 for x in ngrams(data, n=18)]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Migrate requirement from sklearn to scikit-learn since its deprecated.
- Fix the tests, if I understand them correctly.